### PR TITLE
[FIX] Pause button and guideline workflow

### DIFF
--- a/src/components/ui/MinigameGuideline.tsx
+++ b/src/components/ui/MinigameGuideline.tsx
@@ -84,7 +84,6 @@ const MinigameGuideline: FunctionComponent<Props> = props => {
     onLeft,
     onAppeared,
   } = props
-  const { changeConfig } = gameStore
   const [isLeaving, setIsLeaving] = useState(false)
   const [time, setTime] = useState(0)
   const [display, setDisplay] = useState(true)
@@ -109,10 +108,8 @@ const MinigameGuideline: FunctionComponent<Props> = props => {
   )
 
   useEffect(() => {
+    gameStore.showGuideline()
     gameManager.activeScene!.scene.pause()
-    changeConfig({
-      suspended: true,
-    })
     const endHandler = (evt: AnimationEvent) => {
       if (evt.animationName === guidelineAppear.getName()) {
         if (onAppeared) {
@@ -124,9 +121,6 @@ const MinigameGuideline: FunctionComponent<Props> = props => {
           onLeft()
         }
         gameManager.activeScene!.scene.resume()
-        changeConfig({
-          suspended: false,
-        })
         setDisplay(false)
       }
     }
@@ -158,6 +152,7 @@ const MinigameGuideline: FunctionComponent<Props> = props => {
   }, [])
 
   if (!display) {
+    gameStore.hideGuideline()
     return null
   }
 

--- a/src/components/ui/games/GamePauseButton.tsx
+++ b/src/components/ui/games/GamePauseButton.tsx
@@ -49,16 +49,12 @@ const Button = styled.button<StyledProps>`
 `
 
 const GamePauseButton: FunctionComponent = () => {
-  const {
-    paused,
-    canPause,
-    config: { suspended },
-  } = gameStore
+  const { paused, canPause, showingGuideline } = gameStore
   const { togglePause } = gameManager
 
   return (
     <Button
-      disabled={suspended || !canPause}
+      disabled={showingGuideline || !canPause}
       paused={paused}
       onClick={togglePause}
     >

--- a/src/store/GameStore.ts
+++ b/src/store/GameStore.ts
@@ -20,6 +20,7 @@ class GameStore {
   @observable public state: GameState = GameState.Splashscreen
   @observable public difficulty: number = 1
   @observable public loading: boolean = true
+  @observable public showingGuideline: boolean = false
   @observable public started: boolean = false
   @observable public status: TokiStatus = {
     hasStress: false,
@@ -59,6 +60,14 @@ class GameStore {
         })
       }
     )
+  }
+
+  @action public showGuideline = (): void => {
+    this.showingGuideline = true
+  }
+
+  @action public hideGuideline = (): void => {
+    this.showingGuideline = false
   }
 
   @action public decreasePauseRemaining = (): void => {

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -98,14 +98,17 @@ export const useClassTheme = (forceTheme?: GameDebugTheme): string | null => {
   return null
 }
 
-export const useGameloop = (onLoop: () => void): void => {
+export const useGameloop = (
+  onLoop: () => void,
+  inputs: InputIdentityList = []
+): void => {
   useEffect(() => {
     gameManager.activeScene!.time.addEvent({
       callback: onLoop,
       delay: 16,
       repeat: -1,
     })
-  }, [])
+  }, inputs)
 }
 
 export const useInterval = (


### PR DESCRIPTION
## 📋 Spécifications techniques
<!-- Globalement, décris en gros ce que t'as fait dans cette PR dans une liste à puce claire et concise -->
Correction d'un bug avec le bouton de pause et la logique d'affichage des guidelines d'un jeu. Le jeu démarrait automatiquement lorsque la guideline disparaissait, malgré le fait qu'un mini jeu avait une animations d'introduction où le temps n'est pas censé s'écouler
- [x] Modification de la logique qui s'occupe de rendre le bouton de pause activé / désactivé 